### PR TITLE
Add history api interaction buttons

### DIFF
--- a/webview-sample/src/extension.ts
+++ b/webview-sample/src/extension.ts
@@ -193,7 +193,6 @@ class CatCodingPanel {
 					Use a content security policy to only allow loading images from https or from our extension directory,
 					and only allow scripts that have a specific nonce.
 				-->
-				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; img-src ${webview.cspSource} https:; script-src 'nonce-${nonce}';">
 
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -203,10 +202,9 @@ class CatCodingPanel {
 				<title>Cat Coding</title>
 			</head>
 			<body>
-				<img src="${catGifPath}" width="300" />
-				<h1 id="lines-of-code-counter">0</h1>
-
-				<script nonce="${nonce}" src="${scriptUri}"></script>
+				<button onClick="history.pushState({}, '', '#/testing'); console.log('push state')">push state</button>
+				<button onClick="history.forward(); console.log('forward')">Forward</button>
+				<button onClick="history.back(); console.log('back')">Back</button>
 			</body>
 			</html>`;
 	}


### PR DESCRIPTION
To demonstrate the failure that I'm seeing.

## Steps:

- Checkout this branch
- `cd vscode-extension-samples/webview-sample`
- `npm install`
- `npm run compile`
- `code .`
- Start debugging
- Run `Start cat coding session` command in debug instance of VSCode
- In the webview, click 'push state' button, then 'forward', then 'back' 
- Click debugger 'restart' button in the main instance of VS Code
- When the webview reloads, click 'forward' button, then 'back'

## Expected result

Webview continues to be visible

## Actual result

Webview goes blank